### PR TITLE
Updated scripts to current repo.

### DIFF
--- a/MacOS_Scripts/MeltShinyUpdate.command
+++ b/MacOS_Scripts/MeltShinyUpdate.command
@@ -6,9 +6,10 @@ PROGRAM_DIR="$(dirname "$SCRIPT_DIR")"
 # Get the name of the program directory
 PROGRAM_NAME="$(basename "$PROGRAM_DIR")"
 
-# Check if the program directory is named 'MeltWin2.0-main'
-if [ "$PROGRAM_NAME" != "MeltWin2.0-main" ]; then
-    echo "Error: The parent directory is not 'MeltWin2.0-main'! Exiting..."
+# Check if the program directory is named 'MeltShiny-main'
+# -main signifies this was locally installed by a user from the repository.
+if [ "$PROGRAM_NAME" != "MeltShiny-main" ]; then
+    echo "Error: The parent directory is not 'MeltShiny-main'! Exiting..."
     exit 1
 fi
 

--- a/Windows_Scripts/MeltShinyUpdate.bat
+++ b/Windows_Scripts/MeltShinyUpdate.bat
@@ -16,8 +16,9 @@ cd %SCRIPT_DIR%
 for %%a in (%PROGRAM_DIR%) do set PROGRAM_NAME=%%~nxa
 
 :: Check if the program directory is named 'MeltWin2.0-main'
-if /I not "%PROGRAM_NAME%"=="MeltWin2.0-main" (
-    echo Error: The parent directory is not 'MeltWin2.0-main'! Exiting...
+:: -main signifies this was locally installed by a user from the repository.
+if /I not "%PROGRAM_NAME%"=="MeltShiny-main" (
+    echo Error: The parent directory is not 'MeltShiny-main'! Exiting...
     pause
     exit /b 1
 )


### PR DESCRIPTION
Issue 128 regarded the update scripts no longer working. This was due to the repository name change that was conducted a few weeks prior. Going forward, users who run a local version of the application will download the repository as MeltShiny-main which is now reflected within the local scripts. 

Users of previously installed versions will need to redownload or reclone the repository as it currently is for this new change to take effect. 