### PR TITLE
Reset global variables on new dataset

### DIFF
--- a/code/server.r
+++ b/code/server.r
@@ -91,6 +91,12 @@ server <- function(input, output, session) {
       # If there are no errors in the inputs, proceed with file upload and processing
       else {
 
+        masterFrame <- NULL
+        dataList <- list()
+        numUploads <- 0
+        counter <<- 1
+        numSamples <- NULL
+
         # Verify that inputs are valid to display graph
         is_valid_input <<- TRUE
 
@@ -346,6 +352,7 @@ server <- function(input, output, session) {
   observeEvent(
     eventExpr = input$datasetsUploadedID,
     handlerExpr = {
+      start <<- 1
       if (input$datasetsUploadedID == TRUE) {
         lapply(
           start:numSamples,


### PR DESCRIPTION
This pull request solves #137 

The issue revolved around that a number of variables being global that should've been local variables. In R, global variables persist across the entire R session. The reason the disconnect did not occur locally was because developers would constantly open and terminate a new R session when the quit the application, hence the global variables were reset each time. However if the application is hosted, a user will have their own R session that will persist over page refreshes. A global data frame variable would then persist and contain datasets of previous program runs, which lead to multiple errors. 

This fix simple creates local variables and configures them within server.R to reset upon new dataset uploads. 