### PR TITLE
Issue143

### DIFF
--- a/code/server.r
+++ b/code/server.r
@@ -169,6 +169,7 @@ server <- function(input, output, session) {
         readings <- ncol(noNAData)
 
         # Append each each individual processed dataset into one that holds all the datasets
+        # This is where the pathlengths input is taken from the input, but we need to gather it from the data
         p <- 1
         for (x in 2:readings) {
           col <- noNAData[x]

--- a/code/server.r
+++ b/code/server.r
@@ -38,7 +38,7 @@ server <- function(input, output, session) {
           ))
         }
       }
-      if (input$pathlengthID == "" || (input$helixID == ""&& input$seqID=="") || input$blankSampleID == "" || input$temperatureID == "") {
+      if ((input$helixID == ""&& input$seqID=="") || input$blankSampleID == "" || input$temperatureID == "") {
         is_valid_input <<- FALSE
         showModal(modalDialog(
           title = "Missing Inputs",
@@ -93,9 +93,6 @@ server <- function(input, output, session) {
 
         # Verify that inputs are valid to display graph
         is_valid_input <<- TRUE
-
-        # Store the pathlength information
-        pathlengthInputs <- c(unlist(strsplit(gsub(" ", "", input$pathlengthID), ",")))
 
         # Store the wavelength information
         wavelengthVal <<- input$wavelengthID
@@ -167,19 +164,18 @@ server <- function(input, output, session) {
         tempFrame <- data.frame(matrix(nrow = 0, ncol = 4))
         colnames(tempFrame) <- columns
         readings <- ncol(noNAData)
+        filePathlengths <- preProcessedData[, 1]
 
         # Append each each individual processed dataset into one that holds all the datasets
         # This is where the pathlengths input is taken from the input, but we need to gather it from the data
-        p <- 1
         for (x in 2:readings) {
           col <- noNAData[x]
           sample <- rep(c(counter), times = nrow(noNAData[x]))
-          pathlength <- rep(c(as.numeric(pathlengthInputs[p])), times = nrow(noNAData[x]))
+          pathlength <- filePathlengths
           col <- noNAData[x]
           t <- data.frame(sample, pathlength, noNAData[1], noNAData[x])
           names(t) <- names(tempFrame)
           tempFrame <- rbind(tempFrame, t)
-          p <- p + 1
           counter <<- counter + 1
         }
         dataList <<- append(dataList, list(tempFrame))
@@ -200,7 +196,6 @@ server <- function(input, output, session) {
         disable(selector = '.navbar-nav a[data-value="Help"')
         disable(selector = '.navbar-nav a[data-value="File"')
         disable("blankSampleID")
-        disable("pathlengthID")
         disable("inputFileID")
         disable("datasetsUploadedID")
         disable("noBlanksID")
@@ -245,7 +240,6 @@ server <- function(input, output, session) {
     handlerExpr = {
       if (input$datasetsUploadedID == TRUE) {
         disable("blankSampleID")
-        disable("pathlengthID")
         disable("inputFileID")
         disable("datasetsUploadedID")
         disable("noBlanksID")

--- a/code/ui.R
+++ b/code/ui.R
@@ -28,12 +28,6 @@ ui <- navbarPage(
               value = FALSE,
               inputId = "noBlanksID"
             ),
-            #hr(style = "border-top: 1px solid #000000;"),
-            #textInput(
-            #  label = "Enter the pathlengths",
-            #  placeholder = "E.g: 2,5,3,2",
-            #  inputId = "pathlengthID"
-            #),
             hr(style = "border-top: 1px solid #000000;"),
             selectInput(
               label = "Select the wavelengthID",

--- a/code/ui.R
+++ b/code/ui.R
@@ -28,12 +28,12 @@ ui <- navbarPage(
               value = FALSE,
               inputId = "noBlanksID"
             ),
-            hr(style = "border-top: 1px solid #000000;"),
-            textInput(
-              label = "Enter the pathlengths",
-              placeholder = "E.g: 2,5,3,2",
-              inputId = "pathlengthID"
-            ),
+            #hr(style = "border-top: 1px solid #000000;"),
+            #textInput(
+            #  label = "Enter the pathlengths",
+            #  placeholder = "E.g: 2,5,3,2",
+            #  inputId = "pathlengthID"
+            #),
             hr(style = "border-top: 1px solid #000000;"),
             selectInput(
               label = "Select the wavelengthID",


### PR DESCRIPTION
Fixes Issue #143

Removed the input pathlengths box because the pathlengths are already stored in the .csv file that is also uploaded

This was changed because our client requested it, and it saves time from making the users enter hundreds of individual pathlength values per go

I changed this by having the application read in the pathlengths from the csv and use that for the pathlength value rather than using the box, which means that the box was deprecated and could be removed without any issues

*screenshot not applicable*
