### PR TITLE
Programmatically check uploadedID after initial preprocess

### DIFF
--- a/code/server.r
+++ b/code/server.r
@@ -188,6 +188,9 @@ server <- function(input, output, session) {
         numUploads <<- numUploads + 1
         numSamples <<- counter - 1
         masterFrame <<- rbind(masterFrame, tempFrame)
+
+        # automatically check datasetsuploaded checkbox post-processing
+        updateCheckboxInput(session, "datasetsUploadedID", value = TRUE)
       }
     }
   )


### PR DESCRIPTION
Fixes #148 

**What was changed?**

Essentially the datasets uploaded checkbox signaled the processing of the already uploaded data. 

**Why was it changed?**

It was redundant and only a deterrant to an initial server disconnect issue before we knew what was the root cause. 

**How was it changed?**

I've programmatically had this auto-checked post data upload. After uploading a dataset, processing is immediately initiated. 
