### PR TITLE
Move "Decide if you want to have the molar…” to top #177

### DIFF
--- a/code/ui.R
+++ b/code/ui.R
@@ -50,6 +50,13 @@ ui <- navbarPage(
             inputId = "temperatureID"
           ),
           hr(style = "border-top: 1px solid #000000;"),
+          radioButtons(
+            inputId = "extinctConDecisionID",
+            label = "Decide if you want to have the molar extinction coefficients calculated or provide them manually", # nolint
+            choices = c("Nucleic acid sequence(s)", "Custom molar extinction coefficients"), # nolint
+            selected = "Nucleic acid sequence(s)"
+          ),
+          hr(style = "border-top: 1px solid #000000;"),
           selectInput(
             label = "Specify nucleic acid type",
             choices = c("RNA","DNA"),
@@ -65,13 +72,6 @@ ui <- navbarPage(
           actionButton(
             inputId = "seqHelp",
             icon("question")
-          ),
-          hr(style = "border-top: 1px solid #000000;"),
-          radioButtons(
-            inputId = "extinctConDecisionID",
-            label = "Decide if you want to have the molar extinction coefficients calculated or provide them manually", # nolint
-            choices = c("Nucleic acid sequence(s)", "Custom molar extinction coefficients"), # nolint
-            selected = "Nucleic acid sequence(s)"
           ),
           hr(style = "border-top: 1px solid #000000;"),
           checkboxGroupInput(


### PR DESCRIPTION
Fixes #177

**What was changed?**
I changed the order of the sections
"Specify nucleic acid type"
"Decide if you want to have the molar...".

**Why was it changed?**
The order of the two sections was changed to improve the flow of the ui, which would make it more logical for users to first decide on required information before specifying the nucleic acid type. 

**How was it changed?**

I adjusted the code in the sideBarPanel, moving the section for "Decide if you want..." above the "Specify nucleic acid type"

**How was it tested**

I tested it by running the MeltShiny command to confirm that the "Decide if you want.." section was above the "Specify nucleic acid type" section.

**Screenshots that show the changes (if applicable):**

Before: 
<img width="372" alt="Screenshot 2024-09-29 at 4 02 02 PM" src="https://github.com/user-attachments/assets/364167ed-d87f-476c-8642-5c56e57eb447">

After: 
<img width="217" alt="Screenshot 2024-09-29 at 4 02 14 PM" src="https://github.com/user-attachments/assets/eafeedef-2312-46bf-8681-150891b3bc55">


