### PR TITLE
Add Back Button and Hide Input Section After Dataset Upload #196

### DIFF
--- a/code/server.r
+++ b/code/server.r
@@ -12,6 +12,14 @@ server <- function(input, output, session) {
   observeEvent(input$uploadData, {
     datasetsUploadedID(TRUE)  # Set the reactive value to TRUE on upload data button click
   })
+  observeEvent(input$uploadData, {
+    shinyjs::hide(id = "sidebar")      # Hide the sidebar content
+    shinyjs::show(id = "backButton")   # Show the "Back" button
+  })
+  observeEvent(input$backButton, {
+    shinyjs::show(id = "sidebar")      # Show the sidebar content
+    shinyjs::hide(id = "backButton")   # Hide the "Back" button
+  })
   
   # Prevent Rplots.pdf from generating
   if (!interactive()) pdf(NULL)

--- a/code/ui.R
+++ b/code/ui.R
@@ -27,9 +27,10 @@ ui <- navbarPage(
   tabPanel(
     title = "File",
     fluidPage(
-      sidebarLayout(
+      sidebarLayout(  
         sidebarPanel(
           useShinyjs(),
+          id = "sidebar", #name for hiding or showing the bar
           inlineCSS(css),
           fileInput(
             label = "Select the dataset file",
@@ -127,7 +128,13 @@ ui <- navbarPage(
           )
         ),
         mainPanel(
-          tags$div(id = "placeholder")
+          tags$div(id = "placeholder"),
+          #logic for back button outside of side pannel
+          actionButton(
+            inputId = "backButton",
+            label = "Back",
+            style = "display: none;"
+          )
         )
       )
     )


### PR DESCRIPTION
Fixes #196

**What was changed?**

I added the hiding of the input side bar upon entering a dataset and a back button that would appear after inputting data and make the sidebar reappear. 

**Why was it changed?**

This was changed to make the ui flow better and give a more professional look and user experience.

**How was it changed?**

I added a label to the sidebar and a separate back action button that was not visible upon starting the program. this was done in the ui file. When the upload data button is clicked the sidebar gets hidden and the back button appears and when the back button is clicked this brings up the side bar. this was done by adding logic in the server file for when the buttons are clicked.

**How was it tested**

I tested this by running test files and ensuring you could see the back button and that when clicking it would bring back the sidebar. 
[backButtonCapstoneIssue.pdf](https://github.com/user-attachments/files/17359078/backButtonCapstoneIssue.pdf)



**Screenshots that show the changes (if applicable):**
