### PR TITLE
Automatically Populate "Enter Temperature" Field with Highest Temperature from Data #190

### DIFF
--- a/code/server.r
+++ b/code/server.r
@@ -12,7 +12,7 @@ server <- function(input, output, session) {
   observeEvent(input$uploadData, {
     datasetsUploadedID(TRUE)  # Set the reactive value to TRUE on upload data button click
   })
-  
+
   # Prevent Rplots.pdf from generating
   if (!interactive()) pdf(NULL)
 
@@ -49,7 +49,7 @@ server <- function(input, output, session) {
           ))
         }
       }
-      if ((input$helixID == ""&& input$seqID=="") || input$blankSampleID == "" || input$temperatureID == "") {
+      if ((input$helixID == ""&& input$seqID=="") || input$blankSampleID == "") {
         is_valid_input <<- FALSE
         showModal(modalDialog(
           title = "Missing Inputs",
@@ -158,8 +158,6 @@ server <- function(input, output, session) {
           molStateVal <<- "Monomolecular.2State"
         }
 
-        # Store the temperature used to calculate the concentration with Beers law
-        concTVal <<- as.numeric(gsub(" ", "", input$temperatureID))
 
         # Disable widgets whose values apply to all datasets
         disable("helixID")
@@ -175,6 +173,13 @@ server <- function(input, output, session) {
         fileName <- input$inputFileID$datapath
         raw_data <- read.csv(file = fileName)
 
+        highest_temp <- max(raw_data$Temperature, na.rm = TRUE)
+        updateTextInput(session, "temperatureID", value = highest_temp)
+        
+        # Store the temperature used to calculate the concentration with Beers law
+        concTVal <<- as.numeric(gsub(" ", "", highest_temp))
+
+
         # Sort Sample column from lowest to highest
         data <- raw_data %>% arrange(Sample)
 
@@ -183,7 +188,6 @@ server <- function(input, output, session) {
         numSamples <<- numSamples + length(unique(data$Sample))
         masterFrame <<- rbind(masterFrame, data)
 
- 
       }
     }
   )

--- a/code/server.r
+++ b/code/server.r
@@ -3,10 +3,13 @@
 
 server <- function(input, output, session) {
 
-  #Declare initial value for data upload button check
+  # Declare initial value for data upload button check
   is_valid_input <- FALSE
 
-  #declaring datasetsUploadedID as reactive for upload data button click
+  # Prevent manual input to temperatureID button
+  disable("temperatureID")
+
+  # Declaring datasetsUploadedID as reactive for upload data button click
   datasetsUploadedID <- reactiveVal(FALSE)
 
   observeEvent(input$uploadData, {

--- a/code/ui.R
+++ b/code/ui.R
@@ -56,8 +56,8 @@ ui <- navbarPage(
           ),
           hr(style = "border-top: 1px solid #000000;"),
           textInput(
-            label = "Enter the temperature used to calculate the concentration with Beers law", # nolint
-            value = 90,
+            label = "Auto-populates with the highest temperature found in the dataset. Used to calculate the concentration via Beer's law", # nolint
+            value = "",
             inputId = "temperatureID"
           ),
           hr(style = "border-top: 1px solid #000000;"),


### PR DESCRIPTION
Fixes #190 

**What was changed?**

The textInput that prompts the user to input a temperature now autopopulates with the highest temperature found in the dataset.

**Why was it changed?**

This change was made to aid the user so they won't have to do as many steps to process the data.

**How was it changed?**

The dataset is opened and the highest temperature in the "Temperature" column is extracted. This temperature is inputted into the inputText field so that the user can see which temperature is being used.

**How was it tested**

The program was run with test files and the correct max temperature was found and used.
