### PR TITLE
Dev environment fix

### DIFF
--- a/code/install.R
+++ b/code/install.R
@@ -1,6 +1,7 @@
+#!/usr/bin/env Rscript --vanilla
+
 # install.R handles dependency injection for MeltShiny application.
 
-#!/usr/bin/env Rscript --vanilla
 requiredPackages <- c("dplyr",
                       "DT",
                       "ggplot2",


### PR DESCRIPTION
When following the development environment setup instructions from README.md, I encountered an error when running the MacOS_Scripts/MeltShinyDependenciesInstaller.command. The error was:
```
#!/usr/bin/env Rscript --vanilla ; exit;
MacOS_Scripts/../code/install.R: line 4: syntax error near unexpected token `('
MacOS_Scripts/../code/install.R: line 4: `requiredPackages <- c("dplyr",'
```
**What was changed?**
MeltShinyDependenciesInstall.command was calling code/install.R script. This script did not have the shebang for Rscript at the top of the file (there was a comment at the top instead, followed by the shebang for Rscript line: `#!/usr/bin/env Rscript --vanilla`. Moving this line to the top of the script fixed the problem.

**How was it tested**
After making this change, I ran the MacOS_Scripts/MeltShinyDependenciesInstaller.command again, and the necessary dependencies got installed. After that, I was able to run the application, as described in the README.md file.

*NOTE*
This was not tested on Windows. Please test installing the dependencies on Windows before merging.

