### PR TITLE
Enable Reset Option for Dataset Upload #195

### DIFF
--- a/.github/workflows/deploy-shiny.yaml
+++ b/.github/workflows/deploy-shiny.yaml
@@ -13,8 +13,8 @@ on:
   workflow_dispatch:
 
   # Run the workflow every week on Monday at 11:59 PM
-  schedule:
-    - cron: '59 23 * * 1'
+  #schedule:
+  #  - cron: '59 23 * * 1'
 
 # RUNNING THE DEPLOYMENT
 jobs:

--- a/code/install.R
+++ b/code/install.R
@@ -1,6 +1,7 @@
+#!/usr/bin/env Rscript --vanilla
+
 # install.R handles dependency injection for MeltShiny application.
 
-#!/usr/bin/env Rscript --vanilla
 requiredPackages <- c("dplyr",
                       "DT",
                       "ggplot2",

--- a/code/server.r
+++ b/code/server.r
@@ -3,16 +3,19 @@
 
 server <- function(input, output, session) {
 
-  #Declare initial value for data upload button check
+  # Declare initial value for data upload button check
   is_valid_input <- FALSE
 
-  #declaring datasetsUploadedID as reactive for upload data button click
+  # Prevent manual input to temperatureID button
+  disable("temperatureID")
+
+  # Declaring datasetsUploadedID as reactive for upload data button click
   datasetsUploadedID <- reactiveVal(FALSE)
 
   observeEvent(input$uploadData, {
     datasetsUploadedID(TRUE)  # Set the reactive value to TRUE on upload data button click
   })
-  
+
   # Prevent Rplots.pdf from generating
   if (!interactive()) pdf(NULL)
 
@@ -49,7 +52,7 @@ server <- function(input, output, session) {
           ))
         }
       }
-      if ((input$helixID == ""&& input$seqID=="") || input$blankSampleID == "" || input$temperatureID == "") {
+      if ((input$helixID == ""&& input$seqID=="") || input$blankSampleID == "") {
         is_valid_input <<- FALSE
         showModal(modalDialog(
           title = "Missing Inputs",
@@ -158,8 +161,6 @@ server <- function(input, output, session) {
           molStateVal <<- "Monomolecular.2State"
         }
 
-        # Store the temperature used to calculate the concentration with Beers law
-        concTVal <<- as.numeric(gsub(" ", "", input$temperatureID))
 
         # Disable widgets whose values apply to all datasets
         disable("helixID")
@@ -175,6 +176,13 @@ server <- function(input, output, session) {
         fileName <- input$inputFileID$datapath
         raw_data <- read.csv(file = fileName)
 
+        highest_temp <- max(raw_data$Temperature, na.rm = TRUE)
+        updateTextInput(session, "temperatureID", value = highest_temp)
+        
+        # Store the temperature used to calculate the concentration with Beers law
+        concTVal <<- as.numeric(gsub(" ", "", highest_temp))
+
+
         # Sort Sample column from lowest to highest
         data <- raw_data %>% arrange(Sample)
 
@@ -183,7 +191,6 @@ server <- function(input, output, session) {
         numSamples <<- numSamples + length(unique(data$Sample))
         masterFrame <<- rbind(masterFrame, data)
 
- 
       }
     }
   )

--- a/code/server.r
+++ b/code/server.r
@@ -568,6 +568,11 @@ server <- function(input, output, session) {
     }
   )
 
+  # Navigate back to the "File" tab when "Back to Home" button is pressed.
+  observeEvent(input$backToHome, {
+    updateNavbarPage(session, "navbarPageID", selected = "File")
+  })
+
   # Render all parts of the results table.
   output$individualFitsTable <- DT::renderDataTable({
     table <- valuesT$individualFitData %>%

--- a/code/server.r
+++ b/code/server.r
@@ -6,6 +6,13 @@ server <- function(input, output, session) {
   #Declare initial value for data upload button check
   is_valid_input <- FALSE
 
+  #declaring datasetsUploadedID as reactive for upload data button click
+  datasetsUploadedID <- reactiveVal(FALSE)
+
+  observeEvent(input$uploadData, {
+    datasetsUploadedID(TRUE)  # Set the reactive value to TRUE on upload data button click
+  })
+  
   # Prevent Rplots.pdf from generating
   if (!interactive()) pdf(NULL)
 
@@ -176,8 +183,7 @@ server <- function(input, output, session) {
         numSamples <<- numSamples + length(unique(data$Sample))
         masterFrame <<- rbind(masterFrame, data)
 
-        # automatically check datasetsuploaded checkbox post-processing
-        updateCheckboxInput(session, "datasetsUploadedID", value = TRUE)
+ 
       }
     }
   )
@@ -186,9 +192,9 @@ server <- function(input, output, session) {
 
   # Once all datasets have been uploaded, create the MeltR object and derive necessary information
   observeEvent(
-    eventExpr = input$datasetsUploadedID,
+    eventExpr = datasetsUploadedID(),
     handlerExpr = {
-      if (input$datasetsUploadedID == TRUE) {
+      if (datasetsUploadedID() == TRUE) {
         disable(selector = '.navbar-nav a[data-value="Help"')
         disable(selector = '.navbar-nav a[data-value="File"')
         disable("blankSampleID")
@@ -201,7 +207,7 @@ server <- function(input, output, session) {
         enable(selector = '.navbar-nav a[data-value="File"')
       }
       
-      if (input$datasetsUploadedID == TRUE) {
+      if (datasetsUploadedID() == TRUE) {
         logInfo("CREATING MELTR OBJECT")
         # Send stored input values to the connecter class to create a MeltR object
         myConnecter <<- connecter(
@@ -232,9 +238,9 @@ server <- function(input, output, session) {
 
   # Disable remaining widgets on "Upload" page when all datasets have been uploaded
   observeEvent(
-    eventExpr = input$datasetsUploadedID,
+    eventExpr = datasetsUploadedID(),
     handlerExpr = {
-      if (input$datasetsUploadedID == TRUE) {
+      if (datasetsUploadedID() == TRUE) {
         disable("blankSampleID")
         disable("inputFileID")
         disable("datasetsUploadedID")
@@ -309,7 +315,7 @@ server <- function(input, output, session) {
 
   # Disable "Van't Hoff" tab when method 2 is unselected
   observeEvent(
-    eventExpr = input$datasetsUploadedID,
+    eventExpr = datasetsUploadedID(),
     handlerExpr = {
       if (chosenMethods[2] == FALSE) {
         disable(selector = '.navbar-nav a[data-value="Vant Hoff Plot"')
@@ -321,9 +327,9 @@ server <- function(input, output, session) {
 
   # Disable "Analysis" and "Results tabs until all files have successfully been uploaded
   observeEvent(
-    eventExpr = input$datasetsUploadedID,
+    eventExpr = datasetsUploadedID(),
     handlerExpr = {
-      if (input$datasetsUploadedID == FALSE) {
+      if (datasetsUploadedID() == FALSE) {
         disable(selector = '.navbar-nav a[data-value="Analysis"')
         disable(selector = '.navbar-nav a[data-value="Results"')
       } else {
@@ -337,10 +343,10 @@ server <- function(input, output, session) {
   # Dynamically create n tabs (n = number of samples in master data frame) for
   # the "Graphs" page under the "Analysis" navbarmenu.
   observeEvent(
-    eventExpr = input$datasetsUploadedID,
+    eventExpr = datasetsUploadedID(),
     handlerExpr = {
       start <<- 1
-      if (input$datasetsUploadedID == TRUE) {
+      if (datasetsUploadedID() == TRUE) {
         lapply(
           start:numSamples,
           function(i) {
@@ -411,9 +417,9 @@ server <- function(input, output, session) {
   )
   # Dynamically create the analysis plot for each of the n sample tabs
   observeEvent(
-    eventExpr = input$datasetsUploadedID,
+    eventExpr = datasetsUploadedID(),
     handlerExpr = {
-      if (input$datasetsUploadedID == TRUE) {
+      if (datasetsUploadedID() == TRUE) {
         # Initialize variables for accessing best fit and derivative information
         bestFitXData <<- vector("list", numSamples)
         bestFitYData <<- vector("list", numSamples)
@@ -527,7 +533,7 @@ server <- function(input, output, session) {
 
   # Calls function to create delete buttons and add IDs for each row in the individual fits table
   getListUnder <- reactive({
-    if (input$datasetsUploadedID == TRUE) {
+    if (datasetsUploadedID() == TRUE) {
       individualFitData$Delete <- shinyInput(actionButton, nrow(individualFitData), "delete_",
         label = "Remove",
         style = "color: red;background-color: white",
@@ -541,9 +547,9 @@ server <- function(input, output, session) {
 
   # Assign the reactive data frame for the individual fits table to a reactive value
   observeEvent(
-    eventExpr = input$datasetsUploadedID,
+    eventExpr = datasetsUploadedID(),
     handlerExpr = {
-      if (input$datasetsUploadedID == TRUE) {
+      if (datasetsUploadedID() == TRUE) {
         valuesT <<- reactiveValues(individualFitData = NULL)
         valuesT$individualFitData <- isolate({
           getListUnder()

--- a/code/server.r
+++ b/code/server.r
@@ -481,7 +481,7 @@ server <- function(input, output, session) {
         geom_point() +
         geom_smooth(formula = y ~ x, method = lm, fullrange = TRUE, color = "black", se = F, linewidth = .5, linetype = "dashed") +
         geom_point(data = exclude, shape = 21, fill = NA, color = "black", alpha = 0.25) +
-        labs(y = "Inverse Temperature(K)", x = "ln(Concentration(M))", title = "Van't Hoff") +
+        labs(y = "Inverse Temperature(K)", x = "ln(Concentration(M))", title = "van't Hoff") +
         annotate("text", x = Inf, y = Inf, color = "#333333", label = paste("r = ", toString(rValue)), size = 7, vjust = 1, hjust = 1) +
         theme(plot.title = element_text(hjust = 0.5))
 

--- a/code/ui.R
+++ b/code/ui.R
@@ -295,7 +295,10 @@ ui <- navbarPage(
   ),
   tabPanel(
   title = "Help",
-  fluidPage(tags$head(
+  fluidPage(
+    useShinyjs(),  # Include shinyjs for toggle functionality
+
+    tags$head(
         tags$style(HTML("
           .btn-custom {
             padding: 5px 10px;
@@ -316,7 +319,7 @@ ui <- navbarPage(
           class = "sidebar-panel-custom",
           actionButton("backToHome", "Back to Home", icon = icon("home"), class = "btn-custom")
         ),
-    useShinyjs(),  # Include shinyjs for toggle functionality
+      
     mainPanel(width = 12,  # Set full width for the Help page
       hr(style = "border-top: 1px solid #000000;"),
       
@@ -418,5 +421,6 @@ ui <- navbarPage(
       )
     )
   )
+)
 )
 )

--- a/code/ui.R
+++ b/code/ui.R
@@ -56,8 +56,8 @@ ui <- navbarPage(
           ),
           hr(style = "border-top: 1px solid #000000;"),
           textInput(
-            label = "Enter the temperature used to calculate the concentration with Beers law", # nolint
-            value = 90,
+            label = "Auto-populates with the highest temperature found in the dataset. Used to calculate the concentration via Beer's law", # nolint
+            value = "",
             inputId = "temperatureID"
           ),
           hr(style = "border-top: 1px solid #000000;"),

--- a/code/ui.R
+++ b/code/ui.R
@@ -39,7 +39,7 @@ ui <- navbarPage(
           ),
           hr(style = "border-top: 1px solid #000000;"),
           textInput(
-            label = "Sample number of blank",
+            label = "Cell number of blank",
             value = 1,
             inputId = "blankSampleID"
           ),
@@ -49,10 +49,9 @@ ui <- navbarPage(
             inputId = "noBlanksID"
           ),
           hr(style = "border-top: 1px solid #000000;"),
-          selectInput(
-            label = "Select the wavelength",
-            choices = c("300", "295", "290", "285", "280", "275", "270", "265", "260", "255", "250", "245", "240", "235", "230"), # nolint
-            selected = "260",
+          textInput(
+            label = "Enter the wavelength",
+            value = "260",
             inputId = "wavelengthID"
           ),
           hr(style = "border-top: 1px solid #000000;"),
@@ -125,12 +124,6 @@ ui <- navbarPage(
           actionButton(
             label = "Upload Data",
             inputId = "uploadData"
-          ),
-          hr(style = "border-top: 1px solid #000000;"),
-          checkboxInput(
-            label = "All Datasets Uploaded?",
-            value = FALSE,
-            inputId = "datasetsUploadedID"
           )
         ),
         mainPanel(

--- a/code/ui.R
+++ b/code/ui.R
@@ -186,7 +186,7 @@ ui <- navbarPage(
   navbarMenu(
     title = "Results",
     tabPanel(
-      title = "Vant Hoff Plot",
+      title = "van't Hoff Plot",
       fluidPage(
         sidebarLayout(
           sidebarPanel(
@@ -204,7 +204,7 @@ ui <- navbarPage(
               label = "Reset"
             ),
             hr(style = "border-top: 1px solid #000000;"),
-            h5("Download Vant Hoff:"),
+            h5("Download van't Hoff:"),
             textInput(
               label = "Enter the file name.",
               inputId = "saveNameVantID"
@@ -381,8 +381,8 @@ ui <- navbarPage(
         hr(style = "border-top: 1px solid #000000;"),
         h3("FITTING THE ANALYSIS GRAPHS:"),
         hr(style = "border-top: 1px solid #000000;"),
-        h3("Van't Hoff Plots:"),
-        HTML("The van't hoff page under results shows the van't hoff plot. You may click individual points to remove them from the plot. To remove multiple points in one go you can click and drag on the graph to make a box. This box can be moved to fit over the points you want to remove. Once over the correct points hit the remove button on the side panel. "),
+        h3("van't Hoff Plots:"),
+        HTML("The van't Hoff page under results shows the van't Hoff plot. You may click individual points to remove them from the plot. To remove multiple points in one go you can click and drag on the graph to make a box. This box can be moved to fit over the points you want to remove. Once over the correct points hit the remove button on the side panel. "),
         div(img(src = "VantHoff_1.png", class="img-half", alt = "Screenshot showing the how to remove box of points")),
         div(img(src = "VantHoff_2.png", class="img-half", alt = "Screenshot showing the how to removed box of points")),
         HTML("If you want to restore the plot back to the original version, press the restore button on the side panel. "), 

--- a/code/ui.R
+++ b/code/ui.R
@@ -295,7 +295,27 @@ ui <- navbarPage(
   ),
   tabPanel(
   title = "Help",
-  fluidPage(
+  fluidPage(tags$head(
+        tags$style(HTML("
+          .btn-custom {
+            padding: 5px 10px;
+            background-color: #2C3E50;
+            border: none;
+          }
+          .sidebar-panel-custom {
+            width: 154px;
+            padding: 10px;
+          }
+          .main-panel-custom {
+            margin-left: 200px;
+          }
+        "))
+      ),
+      sidebarLayout(
+        sidebarPanel(
+          class = "sidebar-panel-custom",
+          actionButton("backToHome", "Back to Home", icon = icon("home"), class = "btn-custom")
+        ),
     useShinyjs(),  # Include shinyjs for toggle functionality
     mainPanel(width = 12,  # Set full width for the Help page
       hr(style = "border-top: 1px solid #000000;"),


### PR DESCRIPTION
Fixes https://github.com/oss-slu/MeltShiny/issues/195

What was changed?

I added a reset button to the main page that shows up after an initial upload of data to reset all inputs

Why was it changed?

This allows users to reset all inputs and plug in new data/datasets

How was it changed?
I added to ui.r to create the reset button and created the logic behind it in server.r. Mainly added "update____" to reset all other inputs to their default values and "enable" functions to reenable all inputs

How was it tested

After saving code, I ran the meltShiny command to see if the reset button showed up and if it reset all values when clicked.

Screenshots that show the changes (if applicable):
After Uploading Data:
![image](https://github.com/user-attachments/assets/82c78185-1e99-4da5-80c9-78207c0543c7)

After clicking Reset Button:
![image](https://github.com/user-attachments/assets/b32b56cf-4eb6-494f-ab15-8c77213fd966)
