### PR TITLE
Remove Unnecessary Delete and ID Columns from IndividualFits *.xlsx Ouput #214

### DIFF
--- a/code/server.r
+++ b/code/server.r
@@ -660,34 +660,42 @@ server <- function(input, output, session) {
     }
   )
 
-  # Save the results table in the chosen file format
-  output$downloadTableID <- downloadHandler(
-    filename = function() {
-      paste(input$saveNameTableID, ".", input$tableFileFormatID, sep = "")
-    },
-    content = function(file2) {
-      selectedParts <- list()
-      if ("Individual Fits" %in% input$tableDownloadsPartsID) {
-        selectedParts$IndividualFits <- valuesT$individualFitData %>% select(-c(Delete, ID))
-      }
-      if ("Method Summaries" %in% input$tableDownloadsPartsID) {
-        selectedParts$MethodsSummaries <- summaryDataTable
-      }
-      if ("Percent Error" %in% input$tableDownloadsPartsID) {
-        selectedParts$PercentError <- errorDataTable
-      }
-      if ("All of the Above" %in% input$tableDownloadsPartsID) {
-        selectedParts$IndividualFits <- valuesT$individualFitData
-        selectedParts$MethodsSummaries <- summaryDataTable
-        selectedParts$PercentError <- errorDataTable
-      }
-      if (input$tableFileFormatID == "csv") {
-        write.csv(selectedParts, file = file2)
-      } else {
-        write.xlsx(selectedParts, file = file2)
-      }
+# Save the results table in the chosen file format
+output$downloadTableID <- downloadHandler(
+  filename = function() {
+    paste(input$saveNameTableID, ".", input$tableFileFormatID, sep = "")
+  },
+  content = function(file2) {
+    selectedParts <- list()
+    
+    if ("Individual Fits" %in% input$tableDownloadsPartsID) {
+      individualFitData <- valuesT$individualFitData %>% select(-c(Delete, ID))
+      selectedParts$IndividualFits <- individualFitData
     }
-  )
+    if ("Method Summaries" %in% input$tableDownloadsPartsID) {
+      selectedParts$MethodsSummaries <- summaryDataTable
+    }
+    if ("Percent Error" %in% input$tableDownloadsPartsID) {
+      selectedParts$PercentError <- errorDataTable
+    }
+    if ("All of the Above" %in% input$tableDownloadsPartsID) {
+      selectedParts$IndividualFits <- valuesT$individualFitData %>% select(-c(Delete, ID))
+      selectedParts$MethodsSummaries <- summaryDataTable
+      selectedParts$PercentError <- errorDataTable
+    }
+    
+    # Choose the file format for saving
+    if (input$tableFileFormatID == "csv") {
+      lapply(names(selectedParts), function(name) {
+        write.csv(selectedParts[[name]], file = paste0(file2, "_", name, ".csv"), row.names = FALSE)
+      })
+    } else {
+      write.xlsx(selectedParts, file = file2)
+    }
+  }
+)
+
+      
   # General Information Button
   observeEvent(input$btn_general_info, {
     shinyjs::hide("upload_data_content")

--- a/code/server.r
+++ b/code/server.r
@@ -686,9 +686,7 @@ output$downloadTableID <- downloadHandler(
     
     # Choose the file format for saving
     if (input$tableFileFormatID == "csv") {
-      lapply(names(selectedParts), function(name) {
-        write.csv(selectedParts[[name]], file = paste0(file2, "_", name, ".csv"), row.names = FALSE)
-      })
+      write.csv(selectedParts, file = file2)
     } else {
       write.xlsx(selectedParts, file = file2)
     }


### PR DESCRIPTION
Fixes #214

**What was changed?**
I deleted unnecessary columns from IndividualFits *.xlsx output that is downloaded

**Why was it changed?**
These columns are not necessary, and presented an obstruction to the file's readability and relevance.

**How was it changed?**
I changed the server.r file, specifically lines 663-685. Implemented condiitional removal by adding "select(-c(Delete, ID))" specifically for individual fits. In addition, when "All of the Above" is selected, my additions ensure that the two columns are still not included in IndividualFits. 

**How was it tested**
I reran the MeltShiny command two times, inputted all test data, downloaded the excel file with first "Individual Fits" selected and then with "All of the Above" selected to ensure that the two columns were not present. 

**Screenshots that show the changes (if applicable):**
Before:
<img width="533" alt="before deleted delete:id columns" src="https://github.com/user-attachments/assets/b644c6ab-85aa-48bb-b6e5-feb480f77495">
After:
<img width="457" alt="removed delete:id columns" src="https://github.com/user-attachments/assets/9ad2a6ea-69e1-4557-a2a7-32be4e4be84f">


