### PR TITLE
Automatically Update Individual Fits Data Based on Vant Hoff Plot

### DIFF
--- a/code/server.r
+++ b/code/server.r
@@ -680,17 +680,17 @@ server <- function(input, output, session) {
     content = function(file2) {
       selectedParts <- list()
       if ("Individual Fits" %in% input$tableDownloadsPartsID) {
-        selectedParts$IndividualFits <- individualFitsTable
+        selectedParts$IndividualFits <- filteredFitData()
       }
       if ("Method Summaries" %in% input$tableDownloadsPartsID) {
-        selectedParts$MethodsSummaries <- summaryDataTable
+        selectedParts$MethodsSummaries <- summaryDataReactive()
       }
       if ("Percent Error" %in% input$tableDownloadsPartsID) {
         selectedParts$PercentError <- errorDataTable
       }
       if ("All of the Above" %in% input$tableDownloadsPartsID) {
-        selectedParts$IndividualFits <- valuesT$individualFitData
-        selectedParts$MethodsSummaries <- summaryDataTable
+        selectedParts$IndividualFits <- filteredFitData()
+        selectedParts$MethodsSummaries <- summaryDataReactive()
         selectedParts$PercentError <- errorDataTable
       }
       if (input$tableFileFormatID == "csv") {

--- a/code/server.r
+++ b/code/server.r
@@ -627,6 +627,10 @@ server <- function(input, output, session) {
 
   # Reactive expression to update summary data based on Van't Hoff plot changes
   summaryDataReactive <- reactive({
+    
+    # Update the MeltR Object
+    updateMeltRObject()
+    
     req(datasetsUploadedID())
 
     # Filter summary data based on kept points in Van't Hoff
@@ -645,7 +649,6 @@ server <- function(input, output, session) {
   
   # Render updated Summary Methods Table when summaryDataReactive changes
   output$methodSummaryTable <- renderTable({
-    updateMeltRObject()
     summaryDataReactive()
   })
 

--- a/code/server.r
+++ b/code/server.r
@@ -269,6 +269,25 @@ server <- function(input, output, session) {
     }
   )
 
+  updateMeltRObject <- function() {
+    logInfo("UPDATING MELTR OBJECT")
+    myConnecter <<- connecter(
+      df = masterFrame,
+      NucAcid = helix,
+      wavelength = wavelengthVal,
+      blank = blank,
+      Tm_method = tmMethodVal,
+      outliers = NA,
+      Weight_Tm_M2 = weightedTmVal,
+      Mmodel = molStateVal,
+      methods = chosenMethods,
+      concT = concTVal
+    )
+    myConnecter$constructObject()
+    logInfo("MELTR OBJECT UPDATED")
+  }
+
+
   # Disable remaining widgets on "Upload" page when all datasets have been uploaded
   observeEvent(
     eventExpr = c(datasetsUploadedID(), temperatureUpdatedID),
@@ -626,6 +645,7 @@ server <- function(input, output, session) {
   
   # Render updated Summary Methods Table when summaryDataReactive changes
   output$methodSummaryTable <- renderTable({
+    updateMeltRObject()
     summaryDataReactive()
   })
 


### PR DESCRIPTION
Fixes #216

**What was changed?**
Individual Fits data on the results tab is now displayed. It is automatically changed when points are removed from the Van't Hoff plot.

**Why was it changed?**
The Individual Fits data was not being displayed before.

**How was it changed?**
vals$keeprows is a reactive value which is used to track the points that are left on the Van't Hoff plot. A reactive function called filteredFitData is based on vals$keeprows and ensures that only the data for the current points is displayed on the Individual Fits table of the results tab.

**How was it tested**
Points were removed from the Van't Hoff plot and it was made sure that the same points' data were removed from the Individual Fit table automatically.
