### PR TITLE
Added help message to Sequence Input section

### DIFF
--- a/code/server.r
+++ b/code/server.r
@@ -426,7 +426,9 @@ server <- function(input, output, session) {
     handlerExpr = {
       showModal(modalDialog(
         title = "Help for Specify Sequences",
-        "placeholder text for input sequences help",
+        "Please enter the nucleotide sequence in the correct format. For DNA sequences, 
+         use only A, T, C, and G. For RNA sequences, use only A, U, C, and G. Ensure the 
+         sequence is free from spaces, special characters, or numbers.",
         footer = modalButton("Understood"),
         easyClose = FALSE,
         fade = TRUE


### PR DESCRIPTION
Fixes #228

**What was changed?**
A help message was added to the sequence input section.

**Why was it changed?**
The previous version only had a placeholder instead of a help message.

**How was it changed?**
A descriptive message of what sequences need to be inputted and the exact formats that they need to be in was added.

**How was it tested**
MeltShiny was run and the help button was pressed so the message could be viewed.
![Screenshot (66)](https://github.com/user-attachments/assets/408ade20-eb4b-43eb-91e3-bfed6d745f57)
