### PR TITLE
Prevent Application Freezing with Invalid Sequence Inputs

### DIFF
--- a/code/server.r
+++ b/code/server.r
@@ -78,6 +78,8 @@ server <- function(input, output, session) {
   eventExpr = input$uploadData,
   handlerExpr = {
     logInfo("CHECKING PROGRAM INPUTS")
+    # Initially set is_valid_input to True
+    is_valid_input <<- TRUE
     
     # Check if a file is uploaded
     if (is.null(input$inputFileID)) {
@@ -150,43 +152,6 @@ server <- function(input, output, session) {
         updateTextInput(session, "seqID", value = "")
       }
 
-      # Check if the helixID is RNA or DNA, and validate seqID accordingly
-      if (input$helixID == "RNA") {
-        if (!rna_letters_only(input$seqID)) {
-          is_valid_input <<- FALSE
-          showModal(modalDialog(
-            title = "Invalid RNA Sequence",
-            "Please ensure the sequence contains only valid RNA nucleotides (A, U, G, C).",
-            footer = modalButton("Understood"),
-            easyClose = FALSE,
-            fade = TRUE
-          ))
-          # Reset the seqID input field after error
-          updateTextInput(session, "helixID", value = "RNA")
-          updateTextInput(session, "seqID", value = "")
-        }
-      }
-      else if (input$helixID == "DNA") {
-        if (!dna_letters_only(input$seqID)) {
-          is_valid_input <<- FALSE
-          showModal(modalDialog(
-            title = "Invalid DNA Sequence",
-            "Please ensure the sequence contains only valid DNA nucleotides (A, T, G, C).",
-            footer = modalButton("Understood"),
-            easyClose = FALSE,
-            fade = TRUE
-          ))
-          # Reset the seqID input field after error
-          updateTextInput(session, "helixID", value = "DNA")
-          updateTextInput(session, "seqID", value = "")
-        }
-      }
-      else {
-        # In case helixID is neither RNA nor DNA, show an error
-        # Reset the input fields after error
-        updateTextInput(session, "helixID", value = "RNA")
-        updateTextInput(session, "seqID", value = "")
-      }
 
       # Check if the helixID is RNA or DNA, and validate seqID accordingly
       if (input$helixID == "RNA") {
@@ -231,11 +196,6 @@ server <- function(input, output, session) {
           easyClose = FALSE,
           fade = TRUE
         ))
-      }
-
-
-      # Check for a mismatch between DNA and absorbance wavelength
-      if (strsplit(input$helixID, ",")[[1]][1] == "DNA" && !input$wavelengthID == "260") {
       }
 
 
@@ -303,34 +263,13 @@ server <- function(input, output, session) {
       return()  # Stop further execution
     }
 
-    # RNA nucleotide validation
-    if (strsplit(input$helixID, ",")[[1]][1] == "RNA" && 
-        input$molecularStateID != "Monomolecular" && 
-        (!rna_letters_only(gsub(" ", "", strsplit(input$helixID, ",")[[1]][2])) || 
-         !rna_letters_only(gsub(" ", "", strsplit(input$helixID, ",")[[1]][3])))) {
-      is_valid_input <<- FALSE
-      handleError("Not an RNA Nucleotide", "Use nucleotide U with RNA inputs. The program will reset in 5 seconds.")
-      return()  # Stop further execution
-    }
-
-    # DNA nucleotide validation
-    if (strsplit(input$helixID, ",")[[1]][1] == "DNA" && 
-        input$molecularStateID != "Monomolecular" && 
-        (!dna_letters_only(gsub(" ", "", strsplit(input$helixID, ",")[[1]][2])) || 
-         !dna_letters_only(gsub(" ", "", strsplit(input$helixID, ",")[[1]][3])))) {
-      is_valid_input <<- FALSE
-      handleError("Not a DNA Nucleotide", "Use nucleotide T with DNA inputs. The program will reset in 5 seconds.")
-      return()  # Stop further execution
-    }
-
-    if (is.null(input$wavelengthVal) || wavelengthVal < 200 || wavelengthVal > 280) {
+    if (is.null(input$wavelengthID) || input$wavelengthID < 200 || input$wavelengthID > 280) {
       is_valid_input <<- FALSE
       handleError("Invalid Wavelength", "Wavelength must be between 200 and 280 nm. The program will reset in 5 seconds.")
       return()
     }
 
       # If there are no errors in the inputs, proceed with file upload and processing
-      if (is_valid_input) {
       if (is_valid_input) {
         logInfo("VALID INPUT")
 

--- a/code/server.r
+++ b/code/server.r
@@ -64,12 +64,12 @@ server <- function(input, output, session) {
 
   # Check the nucleotide sequence to check if it belongs to DNA
   dna_letters_only <- function(x) {
-    all(!grepl("[^A, ^G, ^C, ^T]", x))
+    grepl("^[ATGC]+$", x, ignore.case = TRUE)
   }
 
   # Check the nucleotide sequence to check if it belongs to RNA
   rna_letters_only <- function(x) {
-    all(!grepl("[^A, ^G, ^C, ^U]", x))
+    grepl("^[AUGC]+$", x, ignore.case = TRUE)
   }
   
 
@@ -151,23 +151,23 @@ server <- function(input, output, session) {
           fade = TRUE
         ))
       } else if (strsplit(input$helixID, ",")[[1]][1] == "RNA" && !(input$molecularStateID == "Monomolecular") &&
-        ((rna_letters_only(gsub(" ", "", (strsplit(input$helixID, ",")[[1]][2]))) == FALSE) ||
-          (rna_letters_only(gsub(" ", "", (strsplit(input$helixID, ",")[[1]][3]))) == FALSE))) {
+        (!rna_letters_only(gsub(" ", "", strsplit(input$helixID, ",")[[1]][2]))) || 
+        (!rna_letters_only(gsub(" ", "", strsplit(input$helixID, ",")[[1]][3])))) {
         is_valid_input <<- FALSE
         showModal(modalDialog(
-          title = "Not a RNA Nucleotide",
-          "Please use nucleotide U with RNA inputs",
+          title = "Invalid RNA Sequence",
+          "Please ensure the sequence contains only valid RNA nucleotides (A, U, G, C).",
           footer = modalButton("Understood"),
           easyClose = FALSE,
           fade = TRUE
         ))
       } else if (strsplit(input$helixID, ",")[[1]][1] == "DNA" && !(input$molecularStateID == "Monomolecular") &&
-        ((dna_letters_only(gsub(" ", "", (strsplit(input$helixID, ",")[[1]][2]))) == FALSE) ||
-          (dna_letters_only(gsub(" ", "", (strsplit(input$helixID, ",")[[1]][3]))) == FALSE))) {
+        (!dna_letters_only(gsub(" ", "", strsplit(input$helixID, ",")[[1]][2]))) ||
+        (!dna_letters_only(gsub(" ", "", strsplit(input$helixID, ",")[[1]][3])))) {
         is_valid_input <<- FALSE
         showModal(modalDialog(
-          title = "Not a DNA Nucleotide",
-          "Please use the nucleotide T with DNA inputs.",
+          title = "Invalid DNA Sequence",
+          "Please ensure the sequence contains only valid DNA nucleotides (A, T, G, C).",
           footer = modalButton("Understood"),
           easyClose = FALSE,
           fade = TRUE

--- a/code/server.r
+++ b/code/server.r
@@ -145,9 +145,12 @@ server <- function(input, output, session) {
           easyClose = FALSE,
           fade = TRUE
         ))
+        # Reset the input fields after error
         updateTextInput(session, "seqID", value = "")
         datasetsUploadedID(FALSE)
-      } 
+      }
+
+      # Check for a mismatch between DNA and absorbance wavelength
       else if (strsplit(input$helixID, ",")[[1]][1] == "DNA" && !input$wavelengthID == "260") {
         is_valid_input <<- FALSE
         showModal(modalDialog(
@@ -157,9 +160,12 @@ server <- function(input, output, session) {
           easyClose = FALSE,
           fade = TRUE
         ))
+        # Reset the input fields after error
         updateTextInput(session, "seqID", value = "")
         datasetsUploadedID(FALSE)
-      } 
+      }
+
+      # Check if RNA sequence contains invalid nucleotides
       else if (strsplit(input$helixID, ",")[[1]][1] == "RNA" && !(input$molecularStateID == "Monomolecular") &&
         (!rna_letters_only(gsub(" ", "", strsplit(input$helixID, ",")[[1]][2]))) || 
         (!rna_letters_only(gsub(" ", "", strsplit(input$helixID, ",")[[1]][3])))) {
@@ -174,7 +180,9 @@ server <- function(input, output, session) {
         # Reset the input fields after error
         updateTextInput(session, "seqID", value = "")
         datasetsUploadedID(FALSE)
-      } 
+      }
+
+      # Check if DNA sequence contains invalid nucleotides
       else if (strsplit(input$helixID, ",")[[1]][1] == "DNA" && !(input$molecularStateID == "Monomolecular") &&
         (!dna_letters_only(gsub(" ", "", strsplit(input$helixID, ",")[[1]][2]))) ||
         (!dna_letters_only(gsub(" ", "", strsplit(input$helixID, ",")[[1]][3])))) {
@@ -189,7 +197,9 @@ server <- function(input, output, session) {
         # Reset the input fields after error
         updateTextInput(session, "seqID", value = "")
         datasetsUploadedID(FALSE)
-      } 
+      }
+
+      # Check if a file has been uploaded
       else if (is.null(input$inputFileID)) {
         showModal(modalDialog(
           title = "No File",

--- a/code/server.r
+++ b/code/server.r
@@ -304,8 +304,8 @@ server <- function(input, output, session) {
         updateCheckboxInput(session, "noBlanksID", value = FALSE)
 
         # Store the extinction coefficient information
-        helix <<- trimws(strsplit(gsub(" ", "", paste(input$helixID, ",", input$seqID)), ",")[[1]], which = "both")
-
+        helix <<- trimws(strsplit(gsub(" ", "", paste(input$helixID, ",", toupper(input$seqID))), ",")[[1]], which = "both")
+        
         # Store the tm method information
         tmMethodVal <<- toString(input$Tm_methodID)
 

--- a/code/server.r
+++ b/code/server.r
@@ -138,10 +138,17 @@ server <- function(input, output, session) {
       
       if ((input$helixID == "" && input$seqID == "") || input$blankSampleID == "") {
         is_valid_input <<- FALSE
-        handleError("No blanks have been found Please select the no blank option. The program will reset in 5 seconds.")
-        return()       
-      
-      } else if (strsplit(input$helixID, ",")[[1]][1] == "DNA" && !input$wavelengthID == "260") {
+        showModal(modalDialog(
+          title = "Missing Inputs",
+          "Please ensure that all text inputs have been filled out.",
+          footer = modalButton("Understood"),
+          easyClose = FALSE,
+          fade = TRUE
+        ))
+        updateTextInput(session, "seqID", value = "")
+        datasetsUploadedID(FALSE)
+      } 
+      else if (strsplit(input$helixID, ",")[[1]][1] == "DNA" && !input$wavelengthID == "260") {
         is_valid_input <<- FALSE
         showModal(modalDialog(
           title = "Nucleotide to Absorbance Mis-Pair",
@@ -150,7 +157,10 @@ server <- function(input, output, session) {
           easyClose = FALSE,
           fade = TRUE
         ))
-      } else if (strsplit(input$helixID, ",")[[1]][1] == "RNA" && !(input$molecularStateID == "Monomolecular") &&
+        updateTextInput(session, "seqID", value = "")
+        datasetsUploadedID(FALSE)
+      } 
+      else if (strsplit(input$helixID, ",")[[1]][1] == "RNA" && !(input$molecularStateID == "Monomolecular") &&
         (!rna_letters_only(gsub(" ", "", strsplit(input$helixID, ",")[[1]][2]))) || 
         (!rna_letters_only(gsub(" ", "", strsplit(input$helixID, ",")[[1]][3])))) {
         is_valid_input <<- FALSE
@@ -161,7 +171,11 @@ server <- function(input, output, session) {
           easyClose = FALSE,
           fade = TRUE
         ))
-      } else if (strsplit(input$helixID, ",")[[1]][1] == "DNA" && !(input$molecularStateID == "Monomolecular") &&
+        # Reset the input fields after error
+        updateTextInput(session, "seqID", value = "")
+        datasetsUploadedID(FALSE)
+      } 
+      else if (strsplit(input$helixID, ",")[[1]][1] == "DNA" && !(input$molecularStateID == "Monomolecular") &&
         (!dna_letters_only(gsub(" ", "", strsplit(input$helixID, ",")[[1]][2]))) ||
         (!dna_letters_only(gsub(" ", "", strsplit(input$helixID, ",")[[1]][3])))) {
         is_valid_input <<- FALSE
@@ -172,7 +186,11 @@ server <- function(input, output, session) {
           easyClose = FALSE,
           fade = TRUE
         ))
-      } else if (is.null(input$inputFileID)) {
+        # Reset the input fields after error
+        updateTextInput(session, "seqID", value = "")
+        datasetsUploadedID(FALSE)
+      } 
+      else if (is.null(input$inputFileID)) {
         showModal(modalDialog(
           title = "No File",
           "Please include a file upload",


### PR DESCRIPTION
Fixes #232 

**What was changed?**
If invalid sequences are inputted, the system no longer freezes. Instead, it displays an error message and allows the user to reenter a sequence. This is performed for both RNA and DNA. 

**Why was it changed?**
To prevent application freezing and enhance error handling.

**How was it changed?**
Existing error checks were altered to effectively check if sequence inputs are valid. If they are valid, a validator variable is set to true and the program is allowed to continue.

**How was it tested**
The program was run and both RNA and DNA inputs were tested with invalid sequences. The error message was displayed and the user was allowed to reenter a sequence. It was also tested with a valid sequence to ensure that the program operated properly under correct conditions.

**Screenshots that show the changes (if applicable):**
![image](https://github.com/user-attachments/assets/c94471fc-e180-4b80-8949-070ed6399b58)

