### PR TITLE
Prevent Freezing When a High Number is Entered in Wavelength Field

### DIFF
--- a/code/server.r
+++ b/code/server.r
@@ -15,7 +15,6 @@ server <- function(input, output, session) {
   # Declaring temperatureUpdatedID as reactive for manual changes to the temperature
   temperatureUpdatedID <- reactiveVal(FALSE)
 
-
   # reusable error catching function
   handleError <- function(title, message) {
     # Display a modal with a custom title and message
@@ -79,6 +78,19 @@ server <- function(input, output, session) {
     all(!grepl("[^A, ^G, ^C, ^U]", x))
   }
   
+# Validate wavelength input before proceeding
+observeEvent(input$wavelengthID, {
+  wavelength <- suppressWarnings(as.numeric(input$wavelengthID))
+
+  if (is.na(wavelength) || wavelength < 200 || wavelength > 800) {
+    is_valid_input(FALSE)
+    handleError("Invalid Wavelength", "Wavelength must be between 200 and 800 nm. The program will reset in 5 seconds.")
+    return()  # Stops execution immediately
+  }
+
+  is_valid_input(TRUE)
+})
+
   # Handle the inputs and uploaded datasets
   observeEvent(
   eventExpr = input$uploadData,


### PR DESCRIPTION
 Prevent Freezing When a High Number is Entered in Wavelength Field

Fixes #233

**What was changed?**

If a high value is entered in the wavelength field, the application no longer crashes. Instead, it displays an error message and allows the user to reenter a valid wavelength value. 

**Why was it changed?**

To prevent the application from freezing on the user, and enhance current error handling. 

**How was it changed?**
The code was modified to handle potential errors more gracefully by ensuring that reactive variables, like datasetsUploadedID, are consistently treated as logical (TRUE/FALSE) values. This prevents the crash caused by an unexpected character value.

**How was it tested**
I tested values in the range that I presented to ensure that the application wasn't freezing. 

<img width="1511" alt="image" src="https://github.com/user-attachments/assets/8e411efb-f780-4ac1-a029-d06eac47ad36" />


