### PR TITLE
Individual Fits Table Properly Displayed

### DIFF
--- a/code/server.r
+++ b/code/server.r
@@ -794,7 +794,6 @@ server <- function(input, output, session) {
         ),
         escape = F
       )
-    logInfo("RESULTS TABLE RENDERED")
   })
   output$methodSummaryTable <- renderTable({
     summaryDataTable <<- rbind(summaryDataTable, myConnecter$summaryData1())


### PR DESCRIPTION
Fixes #239

**What was changed?**
The Individual Fits table generation code was slightly altered so that it displays and can be downloaded properly. The error was simply that a logging message in the table creation function was creating a block that didn't allow the table to be displayed.

**Why was it changed?**
So that the Individual Fits table can be viewed and downloaded.

**How was it changed?**
A log message was blocking shiny's functionality and not allowing it to continue generating a table. It seems that attempting to write the log to the terminal while generating a shiny table at the same time caused some sort of deadlock or data-flow discrepancy, so the log message was removed.

**How was it tested**
MeltShiny was run, the Individual Fits table was viewed and properly displayed. I downloaded the fits table as an excel file and the data matched what was displayed in-browser. I also used the functionality to delete rows from the individual fits table and then redownloaded the excel file to ensure that the deleted rows were not included.

**Screenshots that show the changes (if applicable):**
![image](https://github.com/user-attachments/assets/5627511d-9026-43f2-b34d-c85c1769effd)

