### PR TITLE
Changing the UI to have an Advanced Setting section

### DIFF
--- a/code/server.r
+++ b/code/server.r
@@ -27,6 +27,7 @@ server <- function(input, output, session) {
       )
     )
     
+    
     # After the modal is closed, reset the session
     observeEvent(input$uploadData, {
       # Wait for the modal to be dismissed before resetting the session
@@ -35,6 +36,10 @@ server <- function(input, output, session) {
       })
     })
   }
+
+  observeEvent(input$toggleAdvanced, {
+    shinyjs::toggle("advancedSettings")  # Toggles visibility on button click
+  })
 
   observeEvent(input$resetData, {
     session$reload()

--- a/code/ui.R
+++ b/code/ui.R
@@ -55,6 +55,23 @@ ui <- navbarPage(
             inputId = "wavelengthID"
           ),
           hr(style = "border-top: 1px solid #000000;"),
+          selectInput(
+            label = "Specify nucleic acid type",
+            choices = c("RNA","DNA"),
+            selected = "RNA",
+            inputId = "helixID"
+          ),
+          hr(style = "border-top: 1px solid #000000;"),
+          textInput(
+            label = "Specify sequences",
+            placeholder = "E.g: CGAAAGGU,ACCUUUCG",
+            inputId = "seqID"
+          ),
+          actionButton(
+            inputId = "seqHelp",
+            icon("question")
+          ),
+          hr(style = "border-top: 1px solid #000000;"),
 
           # Advanced Settings button
           actionButton("toggleAdvanced", "Advanced Settings"),
@@ -76,23 +93,6 @@ ui <- navbarPage(
                 label = "Decide if you want to have the molar extinction coefficients calculated or provide them manually", # nolint
                 choices = c("Nucleic acid sequence(s)", "Custom molar extinction coefficients"), # nolint
                 selected = "Nucleic acid sequence(s)"
-              ),
-              hr(style = "border-top: 1px solid #000000;"),
-              selectInput(
-                label = "Specify nucleic acid type",
-                choices = c("RNA","DNA"),
-                selected = "RNA",
-                inputId = "helixID"
-              ),
-              hr(style = "border-top: 1px solid #000000;"),
-              textInput(
-                label = "Specify sequences",
-                placeholder = "E.g: CGAAAGGU,ACCUUUCG",
-                inputId = "seqID"
-              ),
-              actionButton(
-                inputId = "seqHelp",
-                icon("question")
               ),
               hr(style = "border-top: 1px solid #000000;"),
               checkboxGroupInput(

--- a/code/ui.R
+++ b/code/ui.R
@@ -55,71 +55,82 @@ ui <- navbarPage(
             inputId = "wavelengthID"
           ),
           hr(style = "border-top: 1px solid #000000;"),
-          textInput(
-            label = "Auto-populates with the highest temperature found in the dataset. Used to calculate the concentration via Beer's law", # nolint
-            value = "",
-            inputId = "temperatureID"
-          ),
-          actionButton("submit", "Submit"),  # Submit button for temperature ID
-          hr(style = "border-top: 1px solid #000000;"),
-          radioButtons(
-            inputId = "extinctConDecisionID",
-            label = "Decide if you want to have the molar extinction coefficients calculated or provide them manually", # nolint
-            choices = c("Nucleic acid sequence(s)", "Custom molar extinction coefficients"), # nolint
-            selected = "Nucleic acid sequence(s)"
-          ),
-          hr(style = "border-top: 1px solid #000000;"),
-          selectInput(
-            label = "Specify nucleic acid type",
-            choices = c("RNA","DNA"),
-            selected = "RNA",
-            inputId = "helixID"
-          ),
-          hr(style = "border-top: 1px solid #000000;"),
-          textInput(
-            label = "Specify sequences",
-            placeholder = "E.g: CGAAAGGU,ACCUUUCG",
-            inputId = "seqID"
-          ),
-          actionButton(
-            inputId = "seqHelp",
-            icon("question")
-          ),
-          hr(style = "border-top: 1px solid #000000;"),
-          checkboxGroupInput(
-            label = "Optional methods",
-            inputId = "methodsID",
-            choices = list(
-              "Method 2",
-              "Method 3"
-            ),
-            selected = c(
-              "Method 2",
-              "Method 3"
-            )
-          ),
-          hr(style = "border-top: 1px solid #000000;"),
-          radioButtons(
-            inputId = "Tm_methodID",
-            label = "Choose a Tm method",
-            choices = c("nls", "lm", "polynomial"),
-            selected = "nls"
-          ),
-          checkboxInput(
-            label = "Weighted tm for method 2",
-            value = FALSE,
-            inputId = "weightedTmID"
-          ),
-          actionButton(
-            inputId = "tmHelp",
-            icon("question")
-          ),
-          hr(style = "border-top: 1px solid #000000;"),
-          selectInput(
-            label = "Select the molecular state",
-            choices = c("Heteroduplex", "Homoduplex", "Monomolecular"),
-            selected = "Heteroduplex",
-            inputId = "molecularStateID"
+
+          # Advanced Settings button
+          actionButton("toggleAdvanced", "Advanced Settings"),
+          br(), br(),
+
+          #Hidden Advanced Settings Panel
+          shinyjs::hidden(
+            div(id = "advancedSettings",
+            wellPanel(
+              textInput(
+                label = "Auto-populates with the highest temperature found in the dataset. Used to calculate the concentration via Beer's law", # nolint
+                value = "",
+                inputId = "temperatureID"
+              ),
+              actionButton("submit", "Submit"),  # Submit button for temperature ID
+              hr(style = "border-top: 1px solid #000000;"),
+              radioButtons(
+                inputId = "extinctConDecisionID",
+                label = "Decide if you want to have the molar extinction coefficients calculated or provide them manually", # nolint
+                choices = c("Nucleic acid sequence(s)", "Custom molar extinction coefficients"), # nolint
+                selected = "Nucleic acid sequence(s)"
+              ),
+              hr(style = "border-top: 1px solid #000000;"),
+              selectInput(
+                label = "Specify nucleic acid type",
+                choices = c("RNA","DNA"),
+                selected = "RNA",
+                inputId = "helixID"
+              ),
+              hr(style = "border-top: 1px solid #000000;"),
+              textInput(
+                label = "Specify sequences",
+                placeholder = "E.g: CGAAAGGU,ACCUUUCG",
+                inputId = "seqID"
+              ),
+              actionButton(
+                inputId = "seqHelp",
+                icon("question")
+              ),
+              hr(style = "border-top: 1px solid #000000;"),
+              checkboxGroupInput(
+                label = "Optional methods",
+                inputId = "methodsID",
+                choices = list(
+                  "Method 2",
+                  "Method 3"
+                ),
+                selected = c(
+                  "Method 2",
+                  "Method 3"
+                )
+              ),
+              hr(style = "border-top: 1px solid #000000;"),
+              radioButtons(
+                inputId = "Tm_methodID",
+                label = "Choose a Tm method",
+                choices = c("nls", "lm", "polynomial"),
+                selected = "nls"
+              ),
+              checkboxInput(
+                label = "Weighted tm for method 2",
+                value = FALSE,
+                inputId = "weightedTmID"
+              ),
+              actionButton(
+                inputId = "tmHelp",
+                icon("question")
+              ),
+              hr(style = "border-top: 1px solid #000000;"),
+              selectInput(
+                label = "Select the molecular state",
+                choices = c("Heteroduplex", "Homoduplex", "Monomolecular"),
+                selected = "Heteroduplex",
+                inputId = "molecularStateID"
+              ),
+            ))
           ),
           hr(style = "border-top: 1px solid #000000;"),
           actionButton(


### PR DESCRIPTION
Fixes #240

**What was changed?**

Made an "Advanced Settings" section on the same inputs page, with inputs that are usually default inputs and are rarely changed. Upon clicking the Advanced Settings button, users are able to still change the values if they choose to do so, otherwise everything will remain with the default inputs. This change makes the inputs page cleaner. 

**Why was it changed?**
Since many of the sections have default inputs, the UI is cleaner if these sections are in a separate dropdown. 

**How was it changed?**

I modified the UI file and the server file. I added a button labeled "Advanced Settings" that toggles the visibility of the advanced input fields. I wrapped the advanced input fields inside a div that can be shown/hidden using ShinyJS. Inside server.r, I used "shinyjs::toggle()" to handle the visibility of the section. 

Add a button labeled "Advanced Settings" that toggles the visibility of advanced input fields.
Wrap the advanced input fields inside a div that can be shown/hidden using ShinyJS.
Use shinyjs::toggle() inside server.R to handle the visibility toggle.

**How was it tested**
I tested my code by running the MeltShiny command and seeing if the changes were made correctly and the program still worked with my changes. 

**Screenshots that show the changes (if applicable):**
<img width="1512" alt="Screenshot 2025-02-17 at 12 47 40 AM" src="https://github.com/user-attachments/assets/7399b189-5134-4efa-b0e3-e267b284410a" />
<img width="487" alt="Screenshot 2025-02-17 at 12 48 09 AM" src="https://github.com/user-attachments/assets/67a2de46-59de-4376-8f69-225f70086c09" />
