### PR TITLE
Issue_238

### DIFF
--- a/code/server.r
+++ b/code/server.r
@@ -407,12 +407,15 @@ server <- function(input, output, session) {
         )
         myConnecter$constructObject() 
         # Store data necessary for generating the Vant Hoff plot and the results table
+        # IMPORTANT NOTE there should be no vant hoff plot for molStateVal Monomolecular
         vantData <<- myConnecter$gatherVantData()
         individualFitData <<- myConnecter$indFitTableData()
 
         # Variable that handles the points on the Van't Hoff plot for removal
         if (chosenMethods[2] == TRUE && molStateVal != "Monomolecular.2State") {
           vals <<- reactiveValues(keeprows = rep(TRUE, nrow(vantData)))
+          # Initially render the Vant Hoff Plot
+          renderVantHoffPlot()
         }
       }
     }
@@ -502,7 +505,7 @@ server <- function(input, output, session) {
     handlerExpr = {
       if (chosenMethods[2] == FALSE) {
         disable(selector = '.navbar-nav a[data-value="Vant Hoff Plot"')
-      } else if (chosenMethods[2] == FALSE) {
+      } else if (chosenMethods[2] == TRUE) {
         enable(selector = '.navbar-nav a[data-value="Vant Hoff Plot"')
       }
     }
@@ -679,8 +682,7 @@ server <- function(input, output, session) {
     })
   }
 
-  # Initially render the Vant Hoff Plot
-  renderVantHoffPlot()
+  
 
 
   # Remove points from Van't Hoff plot that are clicked

--- a/code/server.r
+++ b/code/server.r
@@ -414,8 +414,11 @@ server <- function(input, output, session) {
         # Variable that handles the points on the Van't Hoff plot for removal
         if (chosenMethods[2] == TRUE && molStateVal != "Monomolecular.2State") {
           vals <<- reactiveValues(keeprows = rep(TRUE, nrow(vantData)))
+          showTab("navbarPageID", "vantHoffPlotTab")
           # Initially render the Vant Hoff Plot
           renderVantHoffPlot()
+        } else if (molStateVal == "Monomolecular.2State"){
+          hideTab("navbarPageID", "vantHoffPlotTab")
         }
       }
     }

--- a/code/server.r
+++ b/code/server.r
@@ -405,14 +405,13 @@ server <- function(input, output, session) {
           methods = chosenMethods,
           concT = concTVal
         )
-        myConnecter$constructObject()
-
+        myConnecter$constructObject() 
         # Store data necessary for generating the Vant Hoff plot and the results table
         vantData <<- myConnecter$gatherVantData()
         individualFitData <<- myConnecter$indFitTableData()
 
         # Variable that handles the points on the Van't Hoff plot for removal
-        if (chosenMethods[2] == TRUE) {
+        if (chosenMethods[2] == TRUE && molStateVal != "Monomolecular.2State") {
           vals <<- reactiveValues(keeprows = rep(TRUE, nrow(vantData)))
         }
       }

--- a/code/ui.R
+++ b/code/ui.R
@@ -194,6 +194,7 @@ ui <- navbarPage(
     title = "Results",
     tabPanel(
       title = "van't Hoff Plot",
+      value = "vantHoffPlotTab",
       fluidPage(
         sidebarLayout(
           sidebarPanel(

--- a/code/ui.R
+++ b/code/ui.R
@@ -390,7 +390,7 @@ ui <- navbarPage(
         h3("FITTING THE ANALYSIS GRAPHS:"),
         hr(style = "border-top: 1px solid #000000;"),
         h3("van't Hoff Plots:"),
-        HTML("The van't Hoff page under results shows the van't Hoff plot. You may click individual points to remove them from the plot. To remove multiple points in one go you can click and drag on the graph to make a box. This box can be moved to fit over the points you want to remove. Once over the correct points hit the remove button on the side panel. Additionaly there will be no vant hoff plot generated when monomolecular is selected as an option. "),
+        HTML("The van't Hoff page under results shows the van't Hoff plot. You may click individual points to remove them from the plot. To remove multiple points in one go you can click and drag on the graph to make a box. This box can be moved to fit over the points you want to remove. Once over the correct points hit the remove button on the side panel. Additionaly there will be no vant Hoff plot generated when monomolecular is selected as an option. "),
         div(img(src = "van'tHoff.png", class="img-half", alt = "Screenshot showing the how to remove box of points")),
         div(img(src = "RemovedPoints.png", class="img-half", alt = "Screenshot showing the how to removed box of points")),
         HTML("If you want to restore the plot back to the original version, press the restore button on the side panel. "), 

--- a/code/ui.R
+++ b/code/ui.R
@@ -390,7 +390,7 @@ ui <- navbarPage(
         h3("FITTING THE ANALYSIS GRAPHS:"),
         hr(style = "border-top: 1px solid #000000;"),
         h3("van't Hoff Plots:"),
-        HTML("The van't Hoff page under results shows the van't Hoff plot. You may click individual points to remove them from the plot. To remove multiple points in one go you can click and drag on the graph to make a box. This box can be moved to fit over the points you want to remove. Once over the correct points hit the remove button on the side panel. "),
+        HTML("The van't Hoff page under results shows the van't Hoff plot. You may click individual points to remove them from the plot. To remove multiple points in one go you can click and drag on the graph to make a box. This box can be moved to fit over the points you want to remove. Once over the correct points hit the remove button on the side panel. Additionaly there will be no vant hoff plot generated when monomolecular is selected as an option. "),
         div(img(src = "van'tHoff.png", class="img-half", alt = "Screenshot showing the how to remove box of points")),
         div(img(src = "RemovedPoints.png", class="img-half", alt = "Screenshot showing the how to removed box of points")),
         HTML("If you want to restore the plot back to the original version, press the restore button on the side panel. "), 


### PR DESCRIPTION
Fixes #issue_238


I changed the condition to generate vals for removal on the vant hoff plot.

I changed the server functionality and added an additional check on the creation of vals for the vant hoff plot generation.

This was changed because the previous way it was done with the new file conditions made it impossible for it to be compatible with the melt R library and the program would crash.

I am fixing that the program crashes when monomolecular is selected as the molecular state. My issue fixes the code because the function that was called when monomolecular was selected returns null because of the way the source code for melt R was written.

I added an additional clause to the if statement that if monomolecular was selected do not run the function. I kept the function in case later on we change the source code of meltR or need to reference what the original function was accomplishing to fix the vant hoff plot display. 

I only modified the server file on line 414 where the if statement is to run the function. The if statement now includes an additional check for the molecular state to ensure that the vals for the vant hoff plot can be generated. 

I tested this with the new file the client sent over and made sure the program ran, did not crash, and could be reset while executing under the new specified conditions. 

I tested the files with every loginfo statement that pertained to the function vantData and referenced the source code as well to test for all possible variables of the program that could cause the melt R object to not build correctly. 

