### PR TITLE
Issue_251 first derivative displaying incorrectly

### DIFF
--- a/code/global.r
+++ b/code/global.r
@@ -115,7 +115,7 @@ connecter <- setRefClass(
     # Construct the analysis plot
     constructAllPlots = function(sampleNum) {
       logInfo(sprintf("RENDERING ANALYSIS PLOT #%s", sampleNum))
-      data <- .self$object$Derivatives.data[.self$object$Derivatives.data == sampleNum, ]
+      data <- .self$object$Derivatives.data[.self$object$Derivatives.data$Sample == sampleNum, ]
       data2 <- .self$object$Method.1.data[.self$object$Method.1.data$Sample == sampleNum, ]
       coeff <- 4000 # Static number to shrink data to scale
       upper <- max(data$dA.dT) / max(data$Ct) + coeff


### PR DESCRIPTION
Fixes #issue_251

The crucial detail about the program that was changed was the way that data was being read into the creation of plots for the analysis of the melting curves. 

A function was what specifically was changed and it was changed by modifying the variable of a function that was responsible for specifying what data was assigned to be used later for graphical display. 

This was changed because the data that was being used for the first graph was not correct and it was causing formulas that were ran on it to return NA resulting in a feature such as displaying the first derivative not working. 
*Here, describe the issue that you are fixing with this code, and why your code fixes it.*
The issue that is fixed with the code is that the subset of data that is being compared in the function of building the graph was not correct. By adding the additional subset specifier the program now effectively pulls the values that correspond to the correct sample number. 

By adding an additional data subset specifier. 
*Here, get into detail about what files you modified, and talk about the most important lines in regards to fixing the issue.*
Only 1 line was modified and it was line 118 of global.r the line previously read       data <- .self$object$Derivatives.data[.self$object$Derivatives.data == sampleNum, ] and now reads       data <- .self$object$Derivatives.data[.self$object$Derivatives.data$Sample == sampleNum, ]. By adding $Sample we are specifying that we are pulling an additional part of data corresponding to the subset Sample and comparing it to our sample number ie the formula for sample == 1 should pull the data from the csv where sample = 1.

It was tested by using files and ensuring that the first derivative graph displayed correctly as well as for the other samples including 1. 

Debug statements were used to print the value's and additional qualities of every variable for the graphs in construct all plots and the result for the first graph changed to be correct after the implementation of the fix and that all other data for the additional graphs stayed the same. 
**Screenshots that show the changes (if applicable):**
