### PR TITLE
App works for Heteroduplex and Homoduplex files

### DIFF
--- a/code/modules_1.r/meltR_obj_creation.R
+++ b/code/modules_1.r/meltR_obj_creation.R
@@ -1,4 +1,4 @@
-process_meltR_object <- function(datasetsUploadedID, VantHoffPlot) {
+process_meltR_object <- function(datasetsUploadedID, temperatureUpdatedID, VantHoffPlot, input, output, session) {
   req(is_valid_input)
   
   if (datasetsUploadedID() == TRUE) {

--- a/code/modules_2/VantHoffPlot.R
+++ b/code/modules_2/VantHoffPlot.R
@@ -1,4 +1,4 @@
-### modules_2/VantHoffPlot.R
+
 VantHoffPlot <- function(input, output, session, chosenMethods, vantData, vals, datasetsUploadedID, temperatureUpdatedID) {
   output$vantPlot <- renderPlot({
     if (chosenMethods[2] == TRUE) {

--- a/code/server.r
+++ b/code/server.r
@@ -70,7 +70,7 @@ server <- function(input, output, session) {
     if (is_valid_input) {
       session$sendCustomMessage(type = 'scrollToTop', message = list())
       process_valid_input(input, session, datasetsUploadedID)
-      process_meltR_object(datasetsUploadedID)
+      process_meltR_object(datasetsUploadedID, temperatureUpdatedID, VantHoffPlot, input, output, session)
     }
 
     shinyjs::hide("loadingSpinner")  # Hide spinner after work is done


### PR DESCRIPTION
Fixes #257 

**What was changed?**
When creating the meltR object, the correct parameters are passed to be able to create the Vant Hoff plot. 

**Why was it changed?**
With homoduplex and heteroduplex files, the Vant hoff plot wasn't being properly created, causing the application to crash. 

**How was it changed?**
Added new parameters to the process_meltR_object() function, allowing it to properly create the Vant Hoff plot. 

**How was it tested**
Tested with each of homoduplex, heteroduplex, and monomolecular files to ensure the program ran without error and that Vant Hoff plots were created for both homoduplex and heteroduplex files (but not for monomolecular).
