### PR TITLE
Manual Baseline Trimming (Fit) is Functional

### DIFF
--- a/code/modules_2/DynamicTabs.R
+++ b/code/modules_2/DynamicTabs.R
@@ -1,4 +1,4 @@
-DynamicTabs <- function(input, output, session, numSamples, blankInt, datasetsUploadedID, is_valid_input) {
+DynamicTabs <- function(input, output, session, numSamples, blankInt, datasetsUploadedID, is_valid_input, fittingTriggered, plotRefreshTrigger) {
   observeEvent(
     eventExpr = datasetsUploadedID(),
     handlerExpr = {
@@ -52,20 +52,18 @@ DynamicTabs <- function(input, output, session, numSamples, blankInt, datasetsUp
         # Create plots
         for (i in 1:numSamples) {
           if (i != blankInt) {
-            xRange[[i]][1] <<- suppressWarnings(round(min(bestFitXData[[i]])))
-            xRange[[i]][2] <<- suppressWarnings(round(max(bestFitXData[[i]])))
             local({
               myI <- i
 
               output[[paste0("plotBoth", myI)]] <- renderPlotly({
-                analysisPlot <- myConnecter$constructAllPlots(myI)
+                plotRefreshTrigger()
+                analysisPlot <- myConnecter$constructAllPlots(myI, fittingTriggered)
                 if (input[[paste0("bestFit", myI)]] == TRUE) {
                   analysisPlot <- analysisPlot %>% add_lines(x = bestFitXData[[myI]], y = bestFitYData[[myI]], color = "red")
                 }
                 if (input[[paste0("firstDerivative", myI)]] == TRUE) {
                   analysisPlot <- analysisPlot %>% add_trace(x = derivativeXData[[myI]], y = derivativeYData[[myI]], marker = list(color = "green"))
                 }
-
                 analysisPlot
               })
               observeEvent(event_data(source = paste0("plotBoth", myI), event = "plotly_relayout", priority = c("event")), {

--- a/code/server.r
+++ b/code/server.r
@@ -25,6 +25,10 @@ server <- function(input, output, session) {
   # Declaring temperatureUpdatedID as reactive for manual changes to the temperature
   temperatureUpdatedID <- reactiveVal(FALSE)
 
+  # Declaring fittingTriggered as a reactive for manual baseline trimming
+  fittingTriggered <- reactiveVal(FALSE)
+  plotRefreshTrigger <- reactiveVal(0)
+
   observeEvent(input$toggleAdvanced, {
     shinyjs::toggle("advancedSettings")  # Toggles visibility on button click
   })
@@ -54,6 +58,11 @@ server <- function(input, output, session) {
       VantHoffPlot(input, output, session, chosenMethods, vantData, vals, datasetsUploadedID, temperatureUpdatedID)
       temperatureUpdatedID(FALSE)
     }
+  })
+
+  observeEvent(input$manualFitID, {
+    fittingTriggered(TRUE)
+    plotRefreshTrigger(plotRefreshTrigger() + 1)
   })
 
 
@@ -93,7 +102,7 @@ server <- function(input, output, session) {
 
   # Dynamically create n tabs (n = number of samples in master data frame) for
   # the "Graphs" page under the "Analysis" navbarmenu.
-  DynamicTabs(input, output, session, numSamples, blankInt, datasetsUploadedID, is_valid_input)
+  DynamicTabs(input, output, session, numSamples, blankInt, datasetsUploadedID, is_valid_input, fittingTriggered, plotRefreshTrigger)
 
   # Create the Results Table
   ResultsTable(input, output, session, valuesT, datasetsUploadedID, individualFitData, summaryDataTable, errorDataTable, is_valid_input)


### PR DESCRIPTION
Fixes #268 

**What was changed?**
The manual baseline trimming functionality under the Fit tab of the Analysis section was completed and made functional. 
constructAllPlots() was modified to apply baseline trimming.
Reactive values were added to trigger the graphs to refresh with the new baseline trimming.

**Why was it changed?**
Before these changes, the fit button existed but didn't have any functionality. Now, the graphs can be cut off according to the manually set baseline ranges.

**How was it changed?**
constructAllPlots() was modified so that data and data2 are filtered when the fit button is clicked. The graphs will regenerate and use these new filtered datasets.
plotRefreshTrigger was added in server.R so that the plots are refreshed after the fit button is clicked.

**How was it tested**
After uploading a dataset, multiple graphs were clicked and baselines trimmed using the fit button. correct logs were printed out and the graphs were properly re-rendered.
