### PR TITLE
Issue_267 downloading results table works

### DIFF
--- a/code/modules_2/DownloadHandler.R
+++ b/code/modules_2/DownloadHandler.R
@@ -1,5 +1,4 @@
-DownloadHandler <- function(input, output, vantGgPlot, summaryDataTable, errorDataTable, valuesT) {
-  
+DownloadHandler <- function(input, output, vantGgPlot, summaryDataTable, errorDataTable, valuesT, individualFitData) {
   # Save the Van't Hoff Plot in the chosen format
   output$downloadVantID <- downloadHandler(
     filename = function() {
@@ -33,7 +32,11 @@ DownloadHandler <- function(input, output, vantGgPlot, summaryDataTable, errorDa
 
       selectedParts <- list()
       if ("Individual Fits" %in% tableParts || "All of the Above" %in% tableParts) {
-        selectedParts$IndividualFits <- valuesT$individualFitData %>% select(-c(Delete, ID))
+        if(is.null(individualFitData$Delete)){
+          selectedParts$IndividualFits <- individualFitData
+        }else{
+          selectedParts$IndividualFits <- individualFitData %>% select(-c(individualFitData$Delete, individualFitData$ID))
+        }
       }
       if ("Method Summaries" %in% tableParts || "All of the Above" %in% tableParts) {
         selectedParts$MethodsSummaries <- summaryDataTable

--- a/code/server.r
+++ b/code/server.r
@@ -71,6 +71,8 @@ server <- function(input, output, session) {
       session$sendCustomMessage(type = 'scrollToTop', message = list())
       process_valid_input(input, session, datasetsUploadedID)
       process_meltR_object(datasetsUploadedID, temperatureUpdatedID, VantHoffPlot, input, output, session)
+      ResultsTable(input, output, session, valuesT, datasetsUploadedID, individualFitData, summaryDataTable, errorDataTable, is_valid_input)
+      DownloadHandler(input, output, vantGgPlot, summaryDataTable, errorDataTable, valuesT, individualFitData)
     }
 
     shinyjs::hide("loadingSpinner")  # Hide spinner after work is done
@@ -80,13 +82,13 @@ server <- function(input, output, session) {
   })
 
   observeEvent(input$showSidebar, {
-  shinyjs::show("fileSidebarContents")
-  shinyjs::hide("sidebarToggleButton")
-})
+    shinyjs::show("fileSidebarContents")
+    shinyjs::hide("sidebarToggleButton")
+  })
 
 
   
-   FreezeUIParts(input, session, datasetsUploadedID, temperatureUpdatedID)
+  FreezeUIParts(input, session, datasetsUploadedID, temperatureUpdatedID)
 
   # Show the uploaded datasets separately on the uploads page
   DisplayDataTable(input, output, session, dataList, numUploads, is_valid_input)
@@ -96,10 +98,10 @@ server <- function(input, output, session) {
   DynamicTabs(input, output, session, numSamples, blankInt, datasetsUploadedID, is_valid_input)
 
   # Create the Results Table
-  ResultsTable(input, output, session, valuesT, datasetsUploadedID, individualFitData, summaryDataTable, errorDataTable, is_valid_input)
+  
 
   # Download Hanlder to download parts (or all) of the Results Table or Van't Hoff Plot
-  DownloadHandler(input, output, vantGgPlot, summaryDataTable, errorDataTable, valuesT)
+  
 
   # observeEvents for the UI elements
   UIcode(input, session)  


### PR DESCRIPTION
Fixes #issue_267

The logic for the code that handles what data gets piped into the file downloader was changed.

I modified the order in which code executed in the server file and what data was sent into the download handler function.

Previously the results table would not download and display an error in the terminal that the data was null.

The issue was that the download handler function executed before the meltr object was created and the correct data was not getting read into the function. My code executes the download handler last so there is data to be read into it and I updated the function to accept the correct data.

By moving the location of download handler in the server.r function and adding specifically the individual fits data to the function parameters so that it could pass them to the csv for download. 

I modified server.r and downloadhandler.r. The most important line was line 1 of download handler that actually passed the individual fits data into the function because previously there was no data being passed into it. 

I tested this by using a test file and seeing the results of downloading the individual fits table. The results were that the csv file downloaded correctly and could be opened. 

I additionally used log statements to print the data that was being passed into the download handler not only to deduce what specifically caused the bug but also what data had to be passed in order for the csv to download with the correct information.

